### PR TITLE
Bug fix for undefined xml variable when bart_api.routes() called with sched=None

### DIFF
--- a/bart_api/__init__.py
+++ b/bart_api/__init__.py
@@ -76,7 +76,9 @@ class BartApi():
     if sched is None:
       url = "http://api.bart.gov/api/route.aspx?cmd=routes&date=%s&key=%s" % (date,self.api_key)
     else:
-      xml = self.get_xml("http://api.bart.gov/api/route.aspx?cmd=routes&sched=%s&key=%s" % (sched,self.api_key))
+      url = "http://api.bart.gov/api/route.aspx?cmd=routes&sched=%s&key=%s" % (sched,self.api_key)
+      
+    xml = self.get_xml(url)
     raw_routes = xml.findall(".//route")
     routes = []
     for route in raw_routes:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='bart_api',
-    version='0.1-5',
+    version='0.1-6',
     description='a python client that interacts with the bay area rapid transit api',
     url='http://github.com/projectdelphai/bart_api',
     author='Reuben Castelino',


### PR DESCRIPTION
If bart_api.routes() called with sched=None, then xml is undefined at https://github.com/projectdelphai/bart_api/blob/fe1001f6bf581dff27966c0dd7a035d9bd4a4bcc/bart_api/__init__.py#L80
